### PR TITLE
pass command line args to binary

### DIFF
--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.app/Contents/MacOS/{{ cookiecutter.formal_name }}
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.app/Contents/MacOS/{{ cookiecutter.formal_name }}
@@ -2,4 +2,4 @@
 CONTENTS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 export PYTHONPATH="$CONTENTS_DIR/Resources/app":"$CONTENTS_DIR/Resources/app_packages"
 cd "$CONTENTS_DIR/Resources"
-Support/bin/python3 -m {{ cookiecutter.module_name }}
+Support/bin/python3 -m {{ cookiecutter.module_name }} "$@"


### PR DESCRIPTION
<!--- Describe your changes in detail -->
For the rare cases when someone wants to use the bundled app from the command line, it might be nice to pass arguments to the bundled script.  This PR adds ` "$@"` to `.app/Contents/MacOS/app` so that arguments are passed on.  Let me know how you feel about this, and if/how you'd want to test it

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
