### PR TITLE
Add default UTF-8 LC_CTYPE to environment

### DIFF
--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -79,5 +79,10 @@
 		{% endfor %}
 	</array>
 	{% endif %}
+    <key>LSEnvironment</key>
+    <dict>
+        <key>LC_CTYPE</key>
+        <string>UTF-8</string>
+    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
Otherwise, when not run from a terminal with `briefcase run` or `open <app>` the environment is empty and Python's string functions will fall back to US-ASCII instead of UTF-8.

In the Info.plist, I added the key LSEnvironment which contains the key LC_CTYPE which is set to UTF-8. This *is* the system-wide default, but if you open apps from the finder, launchpad or spotlight, no environment variables are set and Python falls back to US-ASCII for string functions. This results in strange behaviour: reading a UTF-8 text file works while developing your app, but fails with an exception after distributing your app. Not fun, ;-).

With this key set, the app environment will contain UTF-8 for character type (CTYPE) hints. I did not set a default *language* to keep the change as minimal as possible.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

This change does not introduce new features.
