### PR TITLE
Test framework v2

### DIFF
--- a/{{ cookiecutter.formal_name }}/briefcase.toml
+++ b/{{ cookiecutter.formal_name }}/briefcase.toml
@@ -2,6 +2,7 @@
 [paths]
 app_path = "{{ cookiecutter.formal_name }}.app/Contents/Resources/app"
 app_packages_path = "{{ cookiecutter.formal_name }}.app/Contents/Resources/app_packages"
+info_plist_path = "{{ cookiecutter.formal_name }}.app/Contents/Info.plist"
 support_path = "{{ cookiecutter.formal_name }}.app/Contents/Resources/support"
 {{ {
     "3.8": "support_revision = 12",


### PR DESCRIPTION
Template modifications to support testing in a macOS app project. The v1 approach didn't support testing apps, only projects. 

The app looks for the `BRIEFCASE_MAIN_MODULE` environment variable at startup; if it exists, that module name is used to start the app, rather than the one named in Info.plist. If this variable exists, the dialog displayed on app failure is also suppressed.

The stub binaries are also updated to incorporate the disabling of optimisation, which interferes with pytest.

Refs https://github.com/beeware/briefcase/pull/962

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
