### PR TITLE
Remove redundant LSEnvironment declaration.

### DIFF
--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -79,10 +79,5 @@
 		{% endfor %}
 	</array>
 	{% endif %}
-    <key>LSEnvironment</key>
-    <dict>
-        <key>LC_CTYPE</key>
-        <string>UTF-8</string>
-    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
Following beeware/briefcase-macOS-Xcode-template#18, we can remove the LSEnvironment declaration from the app metadata.

We also need to rebuild the binaries to incorporate the changes from that PR.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
