### PR TITLE
Bump support package revisions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12-dev" ]
         framework: [ "toga", "pyside2", "pyside6", "ppb", "pygame" ]
         exclude:
           # PySide2 doesn't publish a binary wheel that is compatible
-          # with Python 3.11, and is unlikely to ever do so.
+          # with Python 3.11+, and is unlikely to ever do so.
           - python-version: "3.11"
+            framework: "pyside2"
+          - python-version: "3.12-dev"
             framework: "pyside2"

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -6,13 +6,14 @@ info_plist_path = "{{ cookiecutter.formal_name }}.app/Contents/Info.plist"
 entitlements_path = "Entitlements.plist"
 support_path = "{{ cookiecutter.formal_name }}.app/Contents/Resources/support"
 {{ {
-    "3.8": "support_revision = 12",
-    "3.9": "support_revision = 10",
-    "3.10": "support_revision = 6",
-    "3.11": "support_revision = 1",
+    "3.8": "support_revision = 13",
+    "3.9": "support_revision = 11",
+    "3.10": "support_revision = 7",
+    "3.11": "support_revision = 2",
 }.get(cookiecutter.python_version|py_tag, "") }}
 cleanup_paths = [
     "{{ cookiecutter.formal_name }}.app/Contents/Resources/support/Python.xcframework",
+    "{{ cookiecutter.formal_name }}.app/Contents/Resources/support/platform-site",
 ]
 icon = "{{ cookiecutter.formal_name }}.app/Contents/Resources/{{ cookiecutter.app_name }}.icns"
 {% for extension, doctype in cookiecutter.document_types.items() -%}

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -10,6 +10,7 @@ support_path = "{{ cookiecutter.formal_name }}.app/Contents/Resources/support"
     "3.9": "support_revision = 11",
     "3.10": "support_revision = 7",
     "3.11": "support_revision = 2",
+    "3.12": "support_revision = 0",
 }.get(cookiecutter.python_version|py_tag, "") }}
 cleanup_paths = [
     "{{ cookiecutter.formal_name }}.app/Contents/Resources/support/Python.xcframework",


### PR DESCRIPTION
Update support package version used by macOS App template.

This will also require a rebuild of the app once beeware/briefcase-macOS-Xcode-template#26 lands.

Adds presumptive support for Python 3.12.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
