### PR TITLE
Bump support package revisions.

### DIFF
--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -6,11 +6,11 @@ info_plist_path = "{{ cookiecutter.formal_name }}.app/Contents/Info.plist"
 entitlements_path = "Entitlements.plist"
 support_path = "{{ cookiecutter.formal_name }}.app/Contents/Resources/support"
 {{ {
-    "3.8": "support_revision = 13",
-    "3.9": "support_revision = 11",
-    "3.10": "support_revision = 7",
-    "3.11": "support_revision = 2",
-    "3.12": "support_revision = 1",
+    "3.8": "support_revision = 14",
+    "3.9": "support_revision = 12",
+    "3.10": "support_revision = 8",
+    "3.11": "support_revision = 3",
+    "3.12": "support_revision = 2",
 }.get(cookiecutter.python_version|py_tag, "") }}
 cleanup_paths = [
     "{{ cookiecutter.formal_name }}.app/Contents/Resources/support/Python.xcframework",


### PR DESCRIPTION
Bump support package revisions for macOS builds.

This set of builds correctly sets the minimum macOS target to 11.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
