### PR TITLE
Set minimum macOS version to 11.

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleVersion</key>
 	<string>{{ cookiecutter.build }}</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.12</string>
+	<string>11.0</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>MainModule</key>


### PR DESCRIPTION
Since we're offering ARM64-compatible universal binaries, we should be setting the minimum macOS version to 11 (which was the first version with ARM64 support).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
