### PR TITLE
Rewrite Entitlements.plist to avoid newline issues.

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -19,3 +19,7 @@ ENTITLEMENTS_PATH = Path("Entitlements.plist")
 # This implicitly uses "universal" newlines mode.
 xml_content = ENTITLEMENTS_PATH.read_text()
 ENTITLEMENTS_PATH.open('w', newline='\n').write(xml_content)
+
+INFO_PATH = BIN_PATH.parent / 'Info.plist'
+info_content = INFO_PATH.read_text()
+INFO_PATH.open('w', newline='\n').write(info_content)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -10,3 +10,12 @@ os.rename(BIN_PATH / 'Stub-{{ cookiecutter.python_version|py_tag }}', BIN_PATH /
 # Delete all remaining stubs
 for stub in BIN_PATH.glob("Stub-*"):
     os.unlink(stub)
+
+# The codesign utility in recent macOS fails with obscure errors when presented with
+# CRLF line endings, but in some configurations (e.g. global `core.autocrlf=true`)
+# git may have checked out this repo in a way that put CRLF line endings in Entitlements.plist.
+# The following is thus a no-op most of the time, but it's a simple rewrite of a small file.
+ENTITLEMENTS_PATH = Path("Entitlements.plist")
+# This implicitly uses "universal" newlines mode.
+xml_content = ENTITLEMENTS_PATH.read_text()
+ENTITLEMENTS_PATH.open('w', newline='\n').write(xml_content)


### PR DESCRIPTION
The macOS utility `codesign` fails with obscure, difficult to debug errors when presented with CRLF newlines in an XML format `Entitlements.plist`.

Git can be configured globally to mangle newlines to CRLF (via `core.autocrlf=true`).

Cookiecutter manages the git clone of the template, so there's no easy way for us to set the configuration at the repository level during the template instantiation process.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
To prevent a build failure that bit someone during the PyCon US 2024 sprints, the `post_gen_projecct` hook now reads the `Entitlements.plist` file and writes it back with the LF newlines that `codesign` expects.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

I tested this by generating a new project locally after running `git config --global core.autocrlf true` and verifying that the build fails during signing (and confirmed that the templated file has CRLF newlines). Then, I configured the project to use this branch and successfully built and signed the template app, despite still having the Git option enabled.

Fixes beeware/briefcase#1831

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
