### PR TITLE
Modifications to support framework-style packaging.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,12 @@ jobs:
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13-dev" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
+
+        exclude:
+          # PySide6 hasn't published 3.13 wheels.
+          - python-version: "3.13-dev"
+            framework: "pyside6"
+
+          # Pygame hasn't published 3.13 wheels.
+          - python-version: "3.13-dev"
+            framework: "pygame"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,5 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13-dev" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -1,4 +1,8 @@
 # Generated using Python {{ cookiecutter.python_version }}
+[briefcase]
+# This is the start of the framework-based support package era.
+target_version = "0.3.20"
+
 [paths]
 app_path = "{{ cookiecutter.formal_name }}.app/Contents/Resources/app"
 app_packages_path = "{{ cookiecutter.formal_name }}.app/Contents/Resources/app_packages"

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -4,18 +4,21 @@ app_path = "{{ cookiecutter.formal_name }}.app/Contents/Resources/app"
 app_packages_path = "{{ cookiecutter.formal_name }}.app/Contents/Resources/app_packages"
 info_plist_path = "{{ cookiecutter.formal_name }}.app/Contents/Info.plist"
 entitlements_path = "Entitlements.plist"
-support_path = "{{ cookiecutter.formal_name }}.app/Contents/Resources/support"
+support_path = "{{ cookiecutter.formal_name }}.app/Contents/Frameworks"
+runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
 {{ {
-    "3.8": "support_revision = 14",
-    "3.9": "support_revision = 12",
-    "3.10": "support_revision = 8",
-    "3.11": "support_revision = 3",
-    "3.12": "support_revision = 2",
+    "3.9": "support_revision = 13",
+    "3.10": "support_revision = 9",
+    "3.11": "support_revision = 4",
+    "3.12": "support_revision = 3",
+    "3.13": "support_revision = 0",
 }.get(cookiecutter.python_version|py_tag, "") }}
-stub_binary_revision = 8
+stub_binary_revision = 9
 cleanup_paths = [
-    "{{ cookiecutter.formal_name }}.app/Contents/Resources/support/Python.xcframework",
-    "{{ cookiecutter.formal_name }}.app/Contents/Resources/support/platform-site",
+    "{{ cookiecutter.formal_name }}.app/Contents/Frameworks/Python.framework/**/Headers",
+    "{{ cookiecutter.formal_name }}.app/Contents/Frameworks/Python.framework/**/include",
+    "{{ cookiecutter.formal_name }}.app/Contents/Frameworks/Python.framework/**/config-*-darwin",
+    "{{ cookiecutter.formal_name }}.app/Contents/Frameworks/Python.framework/**/pkg-config",
 ]
 icon = "{{ cookiecutter.formal_name }}.app/Contents/Resources/{{ cookiecutter.app_name }}.icns"
 {% for extension, doctype in cookiecutter.document_types.items() -%}


### PR DESCRIPTION
App template changes to support the use of a dynamically loaded Python.framework.

Refs https://github.com/beeware/Python-Apple-support/pull/191

Also drops Python 3.8 support, and adds Python 3.13 support.

Briefcase-Repo: https://github.com/freakboy3742/briefcase.git
Briefcase-Ref: version-bumps

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
