### PR TITLE
Generalised file associations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Briefcase macOS App Template
+xBriefcase macOS App Template
 ============================
 
 A `Cookiecutter <https://github.com/cookiecutter/cookiecutter/>`__ template for

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-xBriefcase macOS App Template
+Briefcase macOS App Template
 ============================
 
 A `Cookiecutter <https://github.com/cookiecutter/cookiecutter/>`__ template for

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -29,56 +29,96 @@
 	{% if cookiecutter.document_types %}
 	<key>CFBundleDocumentTypes</key>
 	<array>
-		{% for extension, doctype in cookiecutter.document_types.items() %}
+		{% for document_type_id, document_type in cookiecutter.document_types.items() %}
 		<dict>
-			<key>CFBundleTypeName</key>
-			<string>{{ doctype.description }}</string>
-			<key>CFBundleTypeIconFile</key>
-			<string>{{ cookiecutter.app_name }}-{{ extension }}.icns</string>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>{{ extension }}</string>
-			</array>
-			<key>CFBundleTypeMIMETypes</key>
-			<array/>
 			<key>CFBundleTypeRole</key>
-			<string>Viewer</string>
+			<string>{{ "Editor" if document_type.can_edit|default(True) else "Viewer" }}</string>
+			<key>LSHandlerRank</key>
+			<string>{{ document_type.handler_rank | default("Owner") }}</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ extension }}</string>
+				{% if document_type.apple_content_type is defined -%}
+				<string>{{ document_type.apple_content_type }}</string>
+				{%- else -%}
+				<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
+				{%- endif %}
 			</array>
 			<key>LSTypeIsPackage</key>
-			<integer>1</integer>
+			<integer>{{ document_type.is_package | default(False) }}</integer>
 		</dict>
 		{% endfor %}
 	</array>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
-		{% for doctype_id, doctype in cookiecutter.document_types.items() %}
+		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
+		{% if document_type.handler_rank|default("Owner") == "Owner" -%}
 		<dict>
-			<key>UTTypeIdentifier</key>
-			<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ doctype_id }}</string>
-			<key>UTTypeReferenceURL</key>
-			<string>{{ doctype.url }}</string>
-			<key>UTTypeIconFile</key>
-			<string>{{ cookiecutter.app_name }}-{{ doctype_id }}.icns</string>
 			<key>UTTypeConformsTo</key>
 			<array>
-				<string>com.apple.package</string>
+				<string>{{ "com.apple.package" if document_type.is_package|default(False) else "public.data" }}</string>
+				<string>public.content</string>
+				{%- if document_type.apple_conforms_to is defined %}
+				{% for type in document_type.apple_conforms_to -%}
+				<string>{{ type }}</string>
+				{% endfor -%}
+				{% endif %}
 			</array>
 			<key>UTTypeDescription</key>
-			<string>{{ doctype.description }}</string>
+			<string>{{ document_type.description }}</string>
+			<key>UTTypeIconFile</key>
+			<string>{{ cookiecutter.app_name }}-{{ document_type_id }}.icns</string>
+			<key>UTTypeIdentifier</key>
+			{% if document_type.apple_content_type is defined -%}
+			<string>{{ document_type.apple_content_type }}</string>
+			{%- else -%}
+			<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
+			{%- endif %}
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
 				<array>
-					<string>{{ doctype.extension }}</string>
+					<string>{{ document_type.extension }}</string>
 				</array>
 			</dict>
 		</dict>
-		{% endfor %}
+		{% endif -%}
+		{%- endfor %}
 	</array>
-	{% endif %}
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
+		{% if document_type.handler_rank|default("Owner") != "Owner" -%}
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>{{ "com.apple.package" if document_type.is_package|default(False) else "public.data" }}</string>
+				<string>public.content</string>
+				{%- if document_type.apple_conforms_to is defined %}
+				{% for type in document_type.apple_conforms_to -%}
+				<string>{{ type }}</string>
+				{% endfor -%}
+				{% endif %}
+			</array>
+			<key>UTTypeDescription</key>
+			<string>{{ document_type.description }}</string>
+			<key>UTTypeIdentifier</key>
+			{% if document_type.apple_content_type is defined -%}
+			<string>{{ document_type.apple_content_type }}</string>
+			{%- else -%}
+			<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
+			{%- endif %}
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>{{ document_type.extension }}</string>
+				</array>
+			</dict>
+		</dict>
+		{% endif -%}
+		{%- endfor %}
+	</array>
+	{% endif -%}
 {%- if cookiecutter.info -%}
 	{%- for permission, value in cookiecutter.info.items() %}
 	<key>{{ permission }}</key>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -42,8 +42,8 @@
 			<string>{{ macOS.LSHandlerRank | default("Owner") }}</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				{%- if macOS.LSItemContentType is defined %}
-				<string>{{ macOS.LSItemContentType }}</string>
+				{%- if macOS.LSItemContentTypes is defined %}
+				<string>{{ macOS.LSItemContentTypes }}</string>
 				{%- else %}
 				<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
 				{%- endif %}
@@ -64,8 +64,8 @@
 			<key>UTTypeIconFile</key>
 			<string>{{ cookiecutter.app_name }}-{{ document_type_id }}.icns</string>
 			<key>UTTypeIdentifier</key>
-			{% if macOS.LSItemContentType is defined -%}
-			<string>{{ macOS.LSItemContentType }}</string>
+			{% if macOS.LSItemContentTypes is defined -%}
+			<string>{{ macOS.LSItemContentTypes }}</string>
 			{%- else -%}
 			<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
 			{%- endif %}

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -43,7 +43,7 @@
 			<key>LSItemContentTypes</key>
 			<array>
 				{%- if macOS.LSItemContentTypes is defined %}
-				<string>{{ macOS.LSItemContentTypes }}</string>
+				<string>{{ macOS.LSItemContentTypes[0] }}</string>
 				{%- else %}
 				<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
 				{%- endif %}
@@ -65,7 +65,7 @@
 			<string>{{ cookiecutter.app_name }}-{{ document_type_id }}.icns</string>
 			<key>UTTypeIdentifier</key>
 			{% if macOS.LSItemContentTypes is defined -%}
-			<string>{{ macOS.LSItemContentTypes }}</string>
+			<string>{{ macOS.LSItemContentTypes[0] }}</string>
 			{%- else -%}
 			<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
 			{%- endif %}

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -46,8 +46,6 @@
 				<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
 				{%- endif %}
 			</array>
-			<key>LSTypeIsPackage</key>
-			{{ "<true/>" if macOS.LSTypeIsPackage | default(False) else "<false/>"}}
 		</dict>
 		{% endfor %}
 	</array>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -38,10 +38,8 @@
 			<string>{{ macOS.LSHandlerRank | default("Owner") }}</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				{%- if macOS.LSItemContentTypes is defined -%}
-					{% for content_type in macOS.LSItemContentTypes %}
-				<string>{{ content_type }}</string>
-					{%- endfor %}
+				{%- if macOS.LSItemContentTypes is defined %}
+				<string>{{ macOS.LSItemContentTypes }}</string>
 				{%- else %}
 				<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
 				{%- endif %}
@@ -64,7 +62,7 @@
 			<string>{{ cookiecutter.app_name }}-{{ document_type_id }}.icns</string>
 			<key>UTTypeIdentifier</key>
 			{% if macOS.LSItemContentTypes is defined -%}
-			<string>{{ macOS.LSItemContentTypes[0] }}</string>
+			<string>{{ macOS.LSItemContentTypes }}</string>
 			{%- else -%}
 			<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
 			{%- endif %}
@@ -78,7 +76,7 @@
 				</array>
 			</dict>
 		</dict>
-		{%- endmacro %}
+		{% endmacro %}
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
@@ -92,7 +90,7 @@
 	<array>
 		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
 			{% set macOS = document_type.macOS | default({}) -%}
-			{% if macOS.LSHandlerRank|default("Owner") != "Owner" -%}
+			{% if macOS.builtin_type|default(false) is false and macOS.LSHandlerRank|default("Owner") != "Owner" -%}
 		{{ type_declaration(cookiecutter, document_type_id, document_type, macOS) }}
 			{%- endif %}
 		{%- endfor %}

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -38,8 +38,8 @@
 			<string>{{ macOS.LSHandlerRank | default("Owner") }}</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				{%- if macOS.LSItemContentTypes is defined %}
-				<string>{{ macOS.LSItemContentTypes }}</string>
+				{%- if macOS.LSItemContentType is defined %}
+				<string>{{ macOS.LSItemContentType }}</string>
 				{%- else %}
 				<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
 				{%- endif %}
@@ -61,8 +61,8 @@
 			<key>UTTypeIconFile</key>
 			<string>{{ cookiecutter.app_name }}-{{ document_type_id }}.icns</string>
 			<key>UTTypeIdentifier</key>
-			{% if macOS.LSItemContentTypes is defined -%}
-			<string>{{ macOS.LSItemContentTypes }}</string>
+			{% if macOS.LSItemContentType is defined -%}
+			<string>{{ macOS.LSItemContentType }}</string>
 			{%- else -%}
 			<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
 			{%- endif %}

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -26,11 +26,11 @@
 	<string>NSApplication</string>
 	<key>MainModule</key>
 	<string>{{ cookiecutter.module_name }}</string>
-	{% if cookiecutter.document_types %}
+	{% if cookiecutter.document_types -%}
 	<key>CFBundleDocumentTypes</key>
 	<array>
-		{% for document_type_id, document_type in cookiecutter.document_types.items() %}
-			{% set macOS = document_type.macOS | default({}) %}
+		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
+			{% set macOS = document_type.macOS | default({}) -%}
 		<dict>
 			<key>CFBundleTypeRole</key>
 			<string>{{ macOS.CFBundleTypeRole | default("Editor") }}</string>
@@ -47,9 +47,9 @@
 				{%- endif %}
 			</array>
 		</dict>
-		{% endfor %}
+		{%- endfor %}
 	</array>
-		{% macro type_declaration(cookiecutter, document_type_id, document_type, macOS) -%}
+		{%- macro type_declaration(cookiecutter, document_type_id, document_type, macOS) -%}
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>
@@ -85,7 +85,7 @@
 			{% set macOS = document_type.macOS | default({}) -%}
 			{% if macOS.LSHandlerRank|default("Owner") == "Owner" -%}
 		{{ type_declaration(cookiecutter, document_type_id, document_type, macOS) }}
-			{% endif -%}
+			{%- endif %}
 		{%- endfor %}
 	</array>
 	<key>UTImportedTypeDeclarations</key>
@@ -94,10 +94,10 @@
 			{% set macOS = document_type.macOS | default({}) -%}
 			{% if macOS.LSHandlerRank|default("Owner") != "Owner" -%}
 		{{ type_declaration(cookiecutter, document_type_id, document_type, macOS) }}
-			{% endif -%}
+			{%- endif %}
 		{%- endfor %}
 	</array>
-	{% endif -%}
+	{%- endif -%}
 {%- if cookiecutter.info -%}
 	{%- for permission, value in cookiecutter.info.items() %}
 	<key>{{ permission }}</key>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -74,6 +74,8 @@
 				<array>
 					<string>{{ document_type.extension }}</string>
 				</array>
+				<key>public.mime-type</key>
+				<string>{% if document_type.get('mime_type') %}{{ document_type.mime_type }}{% else %}application/x-{{ cookiecutter.app_name }}-{{ document_type_id }}{% endif %}</string>
 			</dict>
 		</dict>
 		{% endmacro %}

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -44,7 +44,7 @@
 				{%- endif %}
 			</array>
 			<key>LSTypeIsPackage</key>
-			<integer>{{ document_type.is_package | default(False) }}</integer>
+			<integer>{{ document_type.is_package | default(False) | int }}</integer>
 		</dict>
 		{% endfor %}
 	</array>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -95,7 +95,7 @@
 	<array>
 		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
 			{% set macOS = document_type.macOS | default({}) -%}
-			{% if macOS.builtin_type|default(false) is false and macOS.LSHandlerRank|default("Owner") != "Owner" -%}
+			{% if macOS.is_core_type|default(false) is false and macOS.LSHandlerRank|default("Owner") != "Owner" -%}
 		{{ type_declaration(cookiecutter, document_type_id, document_type, macOS) }}
 			{%- endif %}
 		{%- endfor %}

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -44,7 +44,7 @@
 				{%- endif %}
 			</array>
 			<key>LSTypeIsPackage</key>
-			<integer>{{ document_type.is_package | default(False) | int }}</integer>
+			{{ "<true/>" if document_type.is_package | default(False) else "<false/>"}}
 		</dict>
 		{% endfor %}
 	</array>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -32,6 +32,10 @@
 		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
 			{% set macOS = document_type.macOS | default({}) -%}
 		<dict>
+			<key>CFBundleTypeName</key>
+			<string>{{ document_type.description }}</string>
+			<key>CFBundleTypeIconFile</key>
+			<string>{{ cookiecutter.app_name }}-{{ document_type_id }}.icns</string>
 			<key>CFBundleTypeRole</key>
 			<string>{{ macOS.CFBundleTypeRole | default("Editor") }}</string>
 			<key>LSHandlerRank</key>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -30,46 +30,47 @@
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		{% for document_type_id, document_type in cookiecutter.document_types.items() %}
+		{% set macOS = document_type.macOS | default({}) %}
 		<dict>
 			<key>CFBundleTypeRole</key>
-			<string>{{ "Editor" if document_type.can_edit|default(True) else "Viewer" }}</string>
+			<string>{{ macOS.CFBundleTypeRole | default("Editor") }}</string>
 			<key>LSHandlerRank</key>
-			<string>{{ document_type.handler_rank | default("Owner") }}</string>
+			<string>{{ macOS.LSHandlerRank | default("Owner") }}</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				{% if document_type.apple_content_type is defined -%}
-				<string>{{ document_type.apple_content_type }}</string>
-				{%- else -%}
+				{%- if macOS.LSItemContentTypes is defined -%}
+				{% for content_type in macOS.LSItemContentTypes %}
+				<string>{{ content_type }}</string>
+				{%- endfor %}
+				{%- else %}
 				<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
 				{%- endif %}
 			</array>
 			<key>LSTypeIsPackage</key>
-			{{ "<true/>" if document_type.is_package | default(False) else "<false/>"}}
+			{{ "<true/>" if macOS.LSTypeIsPackage | default(False) else "<false/>"}}
 		</dict>
 		{% endfor %}
 	</array>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
-		{% if document_type.handler_rank|default("Owner") == "Owner" -%}
+		{% set macOS = document_type.macOS | default({}) %}
+		{% if macOS.LSHandlerRank|default("Owner") == "Owner" -%}
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>
-				<string>{{ "com.apple.package" if document_type.is_package|default(False) else "public.data" }}</string>
-				<string>public.content</string>
-				{%- if document_type.apple_conforms_to is defined %}
-				{% for type in document_type.apple_conforms_to -%}
+				<string>{{ "com.apple.package" if macOS.LSTypeIsPackage|default(False) else "public.data" }}</string>
+				{%- for type in macOS.UTTypeConformsTo | default(["public.content"]) %}
 				<string>{{ type }}</string>
-				{% endfor -%}
-				{% endif %}
+				{%- endfor %}
 			</array>
 			<key>UTTypeDescription</key>
 			<string>{{ document_type.description }}</string>
 			<key>UTTypeIconFile</key>
 			<string>{{ cookiecutter.app_name }}-{{ document_type_id }}.icns</string>
 			<key>UTTypeIdentifier</key>
-			{% if document_type.apple_content_type is defined -%}
-			<string>{{ document_type.apple_content_type }}</string>
+			{% if macOS.LSItemContentTypes is defined -%}
+			<string>{{ macOS.LSItemContentTypes[0] }}</string>
 			{%- else -%}
 			<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
 			{%- endif %}
@@ -87,23 +88,23 @@
 	<key>UTImportedTypeDeclarations</key>
 	<array>
 		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
-		{% if document_type.handler_rank|default("Owner") != "Owner" -%}
+		{% set macOS = document_type.macOS | default({}) %}
+		{% if macOS.LSHandlerRank|default("Owner") != "Owner" -%}
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>
-				<string>{{ "com.apple.package" if document_type.is_package|default(False) else "public.data" }}</string>
-				<string>public.content</string>
-				{%- if document_type.apple_conforms_to is defined %}
-				{% for type in document_type.apple_conforms_to -%}
+				<string>{{ "com.apple.package" if macOS.LSTypeIsPackage|default(False) else "public.data" }}</string>
+				{%- for type in macOS.UTTypeConformsTo | default(["public.content"]) %}
 				<string>{{ type }}</string>
-				{% endfor -%}
-				{% endif %}
+				{%- endfor %}
 			</array>
 			<key>UTTypeDescription</key>
 			<string>{{ document_type.description }}</string>
+			<key>UTTypeIconFile</key>
+			<string>{{ cookiecutter.app_name }}-{{ document_type_id }}.icns</string>
 			<key>UTTypeIdentifier</key>
-			{% if document_type.apple_content_type is defined -%}
-			<string>{{ document_type.apple_content_type }}</string>
+			{% if macOS.LSItemContentTypes is defined -%}
+			<string>{{ macOS.LSItemContentTypes[0] }}</string>
 			{%- else -%}
 			<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
 			{%- endif %}

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -68,6 +68,8 @@
 			{%- else -%}
 			<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
 			{%- endif %}
+			<key>UTTypeReferenceURL</key>
+			<string>{{ document_type.url }}</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -51,8 +51,7 @@
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>
-				<string>{{ "com.apple.package" if macOS.LSTypeIsPackage|default(False) else "public.data" }}</string>
-				{%- for type in macOS.UTTypeConformsTo | default(["public.content"]) %}
+				{%- for type in macOS.UTTypeConformsTo %}
 				<string>{{ type }}</string>
 				{%- endfor %}
 			</array>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -45,7 +45,7 @@
 				{%- endif %}
 			</array>
 		</dict>
-		{%- endfor %}
+		{% endfor %}
 	</array>
 		{%- macro type_declaration(cookiecutter, document_type_id, document_type, macOS) -%}
 		<dict>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -30,7 +30,7 @@
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		{% for document_type_id, document_type in cookiecutter.document_types.items() %}
-		{% set macOS = document_type.macOS | default({}) %}
+			{% set macOS = document_type.macOS | default({}) %}
 		<dict>
 			<key>CFBundleTypeRole</key>
 			<string>{{ macOS.CFBundleTypeRole | default("Editor") }}</string>
@@ -39,9 +39,9 @@
 			<key>LSItemContentTypes</key>
 			<array>
 				{%- if macOS.LSItemContentTypes is defined -%}
-				{% for content_type in macOS.LSItemContentTypes %}
+					{% for content_type in macOS.LSItemContentTypes %}
 				<string>{{ content_type }}</string>
-				{%- endfor %}
+					{%- endfor %}
 				{%- else %}
 				<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
 				{%- endif %}
@@ -49,7 +49,7 @@
 		</dict>
 		{% endfor %}
 	</array>
-	{% macro type_declaration(cookiecutter, document_type_id, document_type, macOS) -%}
+		{% macro type_declaration(cookiecutter, document_type_id, document_type, macOS) -%}
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>
@@ -78,23 +78,23 @@
 				</array>
 			</dict>
 		</dict>
-	{%- endmacro %}
+		{%- endmacro %}
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
-		{% set macOS = document_type.macOS | default({}) -%}
-		{% if macOS.LSHandlerRank|default("Owner") == "Owner" -%}
+			{% set macOS = document_type.macOS | default({}) -%}
+			{% if macOS.LSHandlerRank|default("Owner") == "Owner" -%}
 		{{ type_declaration(cookiecutter, document_type_id, document_type, macOS) }}
-		{% endif -%}
+			{% endif -%}
 		{%- endfor %}
 	</array>
 	<key>UTImportedTypeDeclarations</key>
 	<array>
 		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
-		{% set macOS = document_type.macOS | default({}) -%}
-		{% if macOS.LSHandlerRank|default("Owner") != "Owner" -%}
+			{% set macOS = document_type.macOS | default({}) -%}
+			{% if macOS.LSHandlerRank|default("Owner") != "Owner" -%}
 		{{ type_declaration(cookiecutter, document_type_id, document_type, macOS) }}
-		{% endif -%}
+			{% endif -%}
 		{%- endfor %}
 	</array>
 	{% endif -%}

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -37,9 +37,9 @@
 			<key>CFBundleTypeIconFile</key>
 			<string>{{ cookiecutter.app_name }}-{{ document_type_id }}.icns</string>
 			<key>CFBundleTypeRole</key>
-			<string>{{ macOS.CFBundleTypeRole | default("Editor") }}</string>
+			<string>{{ macOS.CFBundleTypeRole }}</string>
 			<key>LSHandlerRank</key>
-			<string>{{ macOS.LSHandlerRank | default("Owner") }}</string>
+			<string>{{ macOS.LSHandlerRank }}</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				{%- if macOS.LSItemContentTypes is defined %}
@@ -86,7 +86,7 @@
 	<array>
 		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
 			{% set macOS = document_type.macOS | default({}) -%}
-			{% if macOS.LSHandlerRank|default("Owner") == "Owner" -%}
+			{% if macOS.LSHandlerRank == "Owner" -%}
 		{{ type_declaration(cookiecutter, document_type_id, document_type, macOS) }}
 			{%- endif %}
 		{%- endfor %}
@@ -95,7 +95,7 @@
 	<array>
 		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
 			{% set macOS = document_type.macOS | default({}) -%}
-			{% if macOS.is_core_type|default(false) is false and macOS.LSHandlerRank|default("Owner") != "Owner" -%}
+			{% if macOS.is_core_type is false and macOS.LSHandlerRank != "Owner" -%}
 		{{ type_declaration(cookiecutter, document_type_id, document_type, macOS) }}
 			{%- endif %}
 		{%- endfor %}

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -51,11 +51,7 @@
 		</dict>
 		{% endfor %}
 	</array>
-	<key>UTExportedTypeDeclarations</key>
-	<array>
-		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
-		{% set macOS = document_type.macOS | default({}) %}
-		{% if macOS.LSHandlerRank|default("Owner") == "Owner" -%}
+	{% macro type_declaration(cookiecutter, document_type_id, document_type, macOS) -%}
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>
@@ -82,40 +78,22 @@
 				</array>
 			</dict>
 		</dict>
+	{%- endmacro %}
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
+		{% set macOS = document_type.macOS | default({}) -%}
+		{% if macOS.LSHandlerRank|default("Owner") == "Owner" -%}
+		{{ type_declaration(cookiecutter, document_type_id, document_type, macOS) }}
 		{% endif -%}
 		{%- endfor %}
 	</array>
 	<key>UTImportedTypeDeclarations</key>
 	<array>
 		{% for document_type_id, document_type in cookiecutter.document_types.items() -%}
-		{% set macOS = document_type.macOS | default({}) %}
+		{% set macOS = document_type.macOS | default({}) -%}
 		{% if macOS.LSHandlerRank|default("Owner") != "Owner" -%}
-		<dict>
-			<key>UTTypeConformsTo</key>
-			<array>
-				<string>{{ "com.apple.package" if macOS.LSTypeIsPackage|default(False) else "public.data" }}</string>
-				{%- for type in macOS.UTTypeConformsTo | default(["public.content"]) %}
-				<string>{{ type }}</string>
-				{%- endfor %}
-			</array>
-			<key>UTTypeDescription</key>
-			<string>{{ document_type.description }}</string>
-			<key>UTTypeIconFile</key>
-			<string>{{ cookiecutter.app_name }}-{{ document_type_id }}.icns</string>
-			<key>UTTypeIdentifier</key>
-			{% if macOS.LSItemContentTypes is defined -%}
-			<string>{{ macOS.LSItemContentTypes[0] }}</string>
-			{%- else -%}
-			<string>{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.{{ document_type_id }}</string>
-			{%- endif %}
-			<key>UTTypeTagSpecification</key>
-			<dict>
-				<key>public.filename-extension</key>
-				<array>
-					<string>{{ document_type.extension }}</string>
-				</array>
-			</dict>
-		</dict>
+		{{ type_declaration(cookiecutter, document_type_id, document_type, macOS) }}
 		{% endif -%}
 		{%- endfor %}
 	</array>


### PR DESCRIPTION
This PR adds file associations to macOS apps. The support in briefcase.toml is already there and the feature is documented. It wasn't yet generalised for non-package file types.

Refs beeware/briefcase#1706, this PR completes the work for macOS.

I tested with https://github.com/davidfokkema/helloworld. This repository may be removed when the PR is merged. The relevant sections of `pyproject.toml` are:
```toml
[tool.briefcase.app.helloworld.document_type.project]
description = "Hello Project File"
extension = "hpf"
is_package = true
icon = "src/helloworld/resources/document"
url = "https://example.com"

[tool.briefcase.app.helloworld.document_type.data]
description = "Hello Data File"
extension = "hda"
can_edit = false
icon = "src/helloworld/resources/document-data"
url = "https://example.com"

[tool.briefcase.app.helloworld.document_type.text]
description = "Regular text file"
extension = "txt"
apple_content_type = "public.text"
apple_conforms_to = ["public.database", "public.spreadsheet"]
handler_rank = "Alternate"
icon = ""
url = "https://example.com"
```
Not all configuration values here make sense; they are mostly intended for testing the functionality. I installed the packaged app in a clean macOS VM and tested the following:
1. project files (.hpf _directories_ since they use the pacakaged format) have an icon and open the app when opening the 'file'. The context-menu shows "Show package contents".
2. data files (.hda) have an icon and open the app when opening the file.
3. text files (.txt) have the default text icon and open Textedit.app when opening the file. However, the context menu "Open with" displays the Hello World app prominently and clicking on that opens the app.

This PR introduces the following configuration keys which all have default values _defined in the template_:
```python
can_edit: bool = True
handler_rank: str = “Owner” (“Owner” | “Default” | “Alternate” | “None”)
apple_content_type: str | None = None (e.g. “public.text”)
is_package: bool = False
apple_conforms_to: list[str] | None = None
```
The new template makes a distinction between _exported_ file types, custom types of which you are the owner, and _imported_ file types defined elsewhere. By default, the files conform to com.apple.package _or_ public.data depending on if they are a package and also public.content to make them airdroppable. If you want more types to conform to, you can specify them in `apple_conforms_to`.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

briefcase-repo: https://github.com/davidfokkema/briefcase
briefcase-ref: file-associations