### PR TITLE
Bump support package revisions; add 3.14 support package.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,10 @@ jobs:
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
+
+        exclude:
+          # No 3.14 wheels for PySide6 or Pygame.
+          - python-version: "3.14"
+            framework: pyside6
+          - python-version: "3.14"
+            framework: pygame

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,5 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,5 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
-
-        exclude:
-          # No 3.14 wheels for PySide6 or Pygame.
-          - python-version: "3.14"
-            framework: pyside6
-          - python-version: "3.14"
-            framework: pygame

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -11,12 +11,12 @@ entitlements_path = "Entitlements.plist"
 support_path = "{{ cookiecutter.formal_name }}.app/Contents/Frameworks"
 runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
 {{ {
-    "3.9": "support_revision = 15",
-    "3.10": "support_revision = 11",
-    "3.11": "support_revision = 6",
-    "3.12": "support_revision = 6",
-    "3.13": "support_revision = 5",
-    "3.14": "support_revision = 1",
+    "3.9": "support_revision = 16",
+    "3.10": "support_revision = 12",
+    "3.11": "support_revision = 7",
+    "3.12": "support_revision = 7",
+    "3.13": "support_revision = 6",
+    "3.14": "support_revision = 2",
 }.get(cookiecutter.python_version|py_tag, "") }}
 stub_binary_revision = 10
 cleanup_paths = [

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -15,7 +15,8 @@ runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
     "3.10": "support_revision = 11",
     "3.11": "support_revision = 6",
     "3.12": "support_revision = 6",
-    "3.13": "support_revision = 3",
+    "3.13": "support_revision = 5",
+    "3.14": "support_revision = 1",
 }.get(cookiecutter.python_version|py_tag, "") }}
 stub_binary_revision = 10
 cleanup_paths = [


### PR DESCRIPTION
* Update the support package for 3.13 to a version that uses the new package-site structure.
* Add an initial 3.14 support package.

This doesn't enable CI testing for 3.14 because of an issue with httpcore (https://github.com/encode/httpcore/discussions/995); that prevents the CI environment from downloading the support package (or doing anything else involving httpx). That also means we can't tag and publish a 3.14 binary in the Xcode repo, which prevents the app tests from running.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
