### PR TITLE
Ensure that installer can work when Rosetta isn't available.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,6 +11,7 @@
     "build": "1",
     "bundle": "com.example",
     "universal_build": true,
+    "host_arch": "x86_64,arm64",
     "python_version": "3.X.0",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,7 +11,7 @@
     "build": "1",
     "bundle": "com.example",
     "universal_build": true,
-    "host_arch": "x86_64,arm64",
+    "host_arch": "arm64",
     "python_version": "3.X.0",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,6 +10,7 @@
     "version": "1.0.0",
     "build": "1",
     "bundle": "com.example",
+    "universal_build": true,
     "python_version": "3.X.0",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension",

--- a/{{ cookiecutter.format }}/installer/Distribution.xml
+++ b/{{ cookiecutter.format }}/installer/Distribution.xml
@@ -3,7 +3,7 @@
     <title>{{ cookiecutter.formal_name }}</title>
     <welcome file="welcome.html" mime-type="text/html" />
     <license file="LICENSE" mime-type="text/plain" />
-    <options customize="never" allow-external-scripts="no"/>
+    <options customize="never" allow-external-scripts="no" hostArchitectures="{% if cookiecutter.universal_build %}x86_64,arm64{% else %}{{ cookiecutter.host_arch }}{% endif %}" />
     <domains enable_localSystem="true" />
     <choices-outline>
         <line choice="{{ cookiecutter.app_name }}"/>


### PR DESCRIPTION
Fixes #75.

macOS PKG installers require an explicit definition of allowed host architectures; without this explicit definition, the installer will fail in non-interactive install mode if Rosetta 2 is not available on the machine where the package is being installed.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
