### PR TITLE
Allow target macOS version to be customizable.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,6 +11,7 @@
     "build": "1",
     "bundle": "com.example",
     "python_version": "3.X.0",
+    "min_os_version": "11.0",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension",
         "briefcase.integrations.cookiecutter.PListExtension"

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleVersion</key>
 	<string>{{ cookiecutter.build }}</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>11.0</string>
+	<string>{{ cookiecutter.min_os_version }}</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>MainModule</key>


### PR DESCRIPTION
Exposes the LSMinimumSystemVersion as a variable that can be configured, using the `min_os_version` setting.

Refs beeware/briefcase#2233.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
