### PR TITLE
Update contribution guide.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 BeeWare <3's contributions!
 
-Please be aware, BeeWare operates under a Code of Conduct.
+Please be aware that BeeWare operates under a [Code of
+Conduct](https://beeware.org/community/behavior/code-of-conduct/).
 
-See [CONTRIBUTING to BeeWare](http://beeware.org/contributing) for details.
+If you'd like to contribute to Briefcase development, our [contribution
+guide](https://briefcase.readthedocs.io/en/latest/how-to/contribute/index.html) details how
+to set up a development environment, and other requirements we have as part of our
+contribution process.


### PR DESCRIPTION
A minor tweak to the contribution guide to match recent changes in Briefcase. 

The real purpose of this change, however, it to test PySide6 CI on Python3.13; Refs beeware/briefcase#2241.

briefcase-repo: https://github.com/freakboy3742/briefcase
briefcase-ref: pyside-macos-12

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
