### PR TITLE
CLI Installer: Create /usr/local/bin if it does not exist (#79)

### DIFF
--- a/{{ cookiecutter.format }}/installer/scripts/postinstall
+++ b/{{ cookiecutter.format }}/installer/scripts/postinstall
@@ -1,6 +1,11 @@
 #!/bin/sh
 echo "Post installation process started"
 
+if [ ! -d "/usr/local/bin" ]; then
+    echo "Creating /usr/local/bin directory"
+    mkdir -p /usr/local/bin
+fi
+
 echo "Install binary symlink"
 ln -si "/Library/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.app/Contents/MacOS/{{ cookiecutter.formal_name }}" /usr/local/bin/{{ cookiecutter.app_name }}
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->

Updates the post-install script to create /usr/local/bin if it does not exist

<!--- What problem does this change solve? -->

If this folder does not already exist (e.g. a clean macOS install), then creating the symlink (that completes installing a CLI app) silently fails.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Fixes #79

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
