### PR TITLE
Bugfix 2071: Where applicable escape double quotes

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -16,6 +16,7 @@
     "min_os_version": "11.0",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension",
-        "briefcase.integrations.cookiecutter.PListExtension"
+        "briefcase.integrations.cookiecutter.PListExtension",
+        "briefcase.integrations.cookiecutter.TOMLEscape"
     ]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -9,6 +9,6 @@ ENTITLEMENTS_PATH = Path("Entitlements.plist")
 xml_content = ENTITLEMENTS_PATH.read_text()
 ENTITLEMENTS_PATH.open('w', newline='\n').write(xml_content)
 
-INFO_PATH = Path("{{ cookiecutter.formal_name }}.app/Contents/Info.plist")
+INFO_PATH = Path("{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Info.plist")
 info_content = INFO_PATH.read_text()
 INFO_PATH.open('w', newline='\n').write(info_content)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -9,6 +9,6 @@ ENTITLEMENTS_PATH = Path("Entitlements.plist")
 xml_content = ENTITLEMENTS_PATH.read_text()
 ENTITLEMENTS_PATH.open('w', newline='\n').write(xml_content)
 
-INFO_PATH = Path("{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Info.plist")
+INFO_PATH = Path("{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Info.plist")
 info_content = INFO_PATH.read_text()
 INFO_PATH.open('w', newline='\n').write(info_content)

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -4,11 +4,11 @@
 target_version = "0.3.20"
 
 [paths]
-app_path = "{{ cookiecutter.formal_name }}.app/Contents/Resources/app"
-app_packages_path = "{{ cookiecutter.formal_name }}.app/Contents/Resources/app_packages"
-info_plist_path = "{{ cookiecutter.formal_name }}.app/Contents/Info.plist"
+app_path = "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Resources/app"
+app_packages_path = "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Resources/app_packages"
+info_plist_path = '{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Info.plist'
 entitlements_path = "Entitlements.plist"
-support_path = "{{ cookiecutter.formal_name }}.app/Contents/Frameworks"
+support_path = "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Frameworks"
 runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
 {{ {
     "3.9": "support_revision = 16",
@@ -20,12 +20,12 @@ runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
 }.get(cookiecutter.python_version|py_tag, "") }}
 stub_binary_revision = 11
 cleanup_paths = [
-    "{{ cookiecutter.formal_name }}.app/Contents/Frameworks/Python.framework/**/Headers",
-    "{{ cookiecutter.formal_name }}.app/Contents/Frameworks/Python.framework/**/include",
-    "{{ cookiecutter.formal_name }}.app/Contents/Frameworks/Python.framework/**/config-*-darwin",
-    "{{ cookiecutter.formal_name }}.app/Contents/Frameworks/Python.framework/**/pkg-config",
+    "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Frameworks/Python.framework/**/Headers",
+    "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Frameworks/Python.framework/**/include",
+    "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Frameworks/Python.framework/**/config-*-darwin",
+    "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Frameworks/Python.framework/**/pkg-config",
 ]
-icon = "{{ cookiecutter.formal_name }}.app/Contents/Resources/{{ cookiecutter.app_name }}.icns"
+icon = "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Resources/{{ cookiecutter.app_name }}.icns"
 {% for extension, doctype in cookiecutter.document_types.items() -%}
-document_type_icon.{{ extension }} = "{{ cookiecutter.formal_name }}.app/Contents/Resources/{{ cookiecutter.app_name }}-{{ extension }}.icns"
+document_type_icon.{{ extension }} = "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Resources/{{ cookiecutter.app_name }}-{{ extension }}.icns"
 {% endfor %}

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -4,11 +4,11 @@
 target_version = "0.3.20"
 
 [paths]
-app_path = "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Resources/app"
-app_packages_path = "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Resources/app_packages"
-info_plist_path = '{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Info.plist'
+app_path = "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Resources/app"
+app_packages_path = "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Resources/app_packages"
+info_plist_path = "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Info.plist"
 entitlements_path = "Entitlements.plist"
-support_path = "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Frameworks"
+support_path = "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Frameworks"
 runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
 {{ {
     "3.9": "support_revision = 16",
@@ -20,12 +20,12 @@ runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
 }.get(cookiecutter.python_version|py_tag, "") }}
 stub_binary_revision = 11
 cleanup_paths = [
-    "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Frameworks/Python.framework/**/Headers",
-    "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Frameworks/Python.framework/**/include",
-    "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Frameworks/Python.framework/**/config-*-darwin",
-    "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Frameworks/Python.framework/**/pkg-config",
+    "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Frameworks/Python.framework/**/Headers",
+    "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Frameworks/Python.framework/**/include",
+    "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Frameworks/Python.framework/**/config-*-darwin",
+    "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Frameworks/Python.framework/**/pkg-config",
 ]
-icon = "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Resources/{{ cookiecutter.app_name }}.icns"
+icon = "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Resources/{{ cookiecutter.app_name }}.icns"
 {% for extension, doctype in cookiecutter.document_types.items() -%}
-document_type_icon.{{ extension }} = "{{ cookiecutter.formal_name|replace('"', '\\"') }}.app/Contents/Resources/{{ cookiecutter.app_name }}-{{ extension }}.icns"
+document_type_icon.{{ extension }} = "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Resources/{{ cookiecutter.app_name }}-{{ extension }}.icns"
 {% endfor %}


### PR DESCRIPTION
This addresses #2071 (details were also left on this comment https://github.com/beeware/briefcase/issues/2071#issuecomment-2891810167)

Formal Names with a double quote was causing invalid strings, this was causing the `post_gen_project` hook for MacOS to fail.

Log error:
```python
Using app template: https://github.com/beeware/briefcase-macOS-app-template.git, branch v0.3.23
Cloning template 'https://github.com/beeware/briefcase-macOS-app-template.git'...
Using existing template (sha f63353430d7c94e2efd4164c9dcd526ba5d03b5e, updated Thu Apr 17 13:23:14 2025)
  File "/var/folders/_p/5_kmj5r5145_n0410jzn6_xh0000gn/T/tmpcb7a8dh2.py", line 12
    INFO_PATH = Path("badFormalName".app/Contents/Info.plist")
                                                         ^
SyntaxError: unterminated string literal (detected at line 12)
Stopping generation because post_gen_project hook script didn't exit successfully
```

One proposed solution was to make the "fix" with `{{ cookiecutter.formal_name|replace('"', '\\"') }}`  [on line 12 of the macOS post gen template script](https://github.com/beeware/briefcase-macOS-app-template/blob/9d8494a5a365c74f03b075aa8f76c48494516b0b/hooks/post_gen_project.py#L12)

However, fixing this caused cascading issues (invalid strings) with the generation of the `briefcase.toml` corresponding to the user's application build.

See example for formal_name as `badFormalName"`
```python
# Generated using Python 3.13.3
[briefcase]
# This is the start of the framework-based support package era.
target_version = "0.3.20"

[paths]
app_path = "badFormalName".app/Contents/Resources/app"
app_packages_path = "badFormalName".app/Contents/Resources/app_packages"
info_plist_path = "badFormalName".app/Contents/Info.plist"
entitlements_path = "Entitlements.plist"
support_path = "badFormalName".app/Contents/Frameworks"
runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
support_revision = 6
stub_binary_revision = 11
cleanup_paths = [
    "badFormalName".app/Contents/Frameworks/Python.framework/**/Headers",
    "badFormalName".app/Contents/Frameworks/Python.framework/**/include",
    "badFormalName".app/Contents/Frameworks/Python.framework/**/config-*-darwin",
    "badFormalName".app/Contents/Frameworks/Python.framework/**/pkg-config",
]
icon = "badFormalName".app/Contents/Resources/badFormalName.icns"
```

Solution:
Use escape_toml extension where applicable, i.e. in paths and string literals.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
