### PR TITLE
Remove cleanup content from original unpack location.

### DIFF
--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -20,10 +20,10 @@ runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
 }.get(cookiecutter.python_version|py_tag, "") }}
 stub_binary_revision = 11
 cleanup_paths = [
-    "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Frameworks/Python.framework/**/Headers",
-    "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Frameworks/Python.framework/**/include",
-    "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Frameworks/Python.framework/**/config-*-darwin",
-    "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Frameworks/Python.framework/**/pkg-config",
+    "support/Python.xcframework/**/Headers",
+    "support/Python.xcframework/**/include",
+    "support/Python.xcframework/**/python*/config-*-darwin",
+    "support/Python.xcframework/**/pkgconfig",
 ]
 icon = "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Resources/{{ cookiecutter.app_name }}.icns"
 {% for extension, doctype in cookiecutter.document_types.items() -%}


### PR DESCRIPTION
Modifies the cleanup paths to remove content from the original unpacking location (`support`) rather than the support path in the bundled app. This slightly reduces the amount of copying, simplifies the cleanup path, and reduces confusion over what content will end up in the final app bundle.

Also corrects the path to remove pkgconfig data, and makes the `config-*-darwin` path more explicit.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
