### PR TITLE
Drop Python 3.9, add 3.14.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
-        # Pygame hasn't published 3.14 wheels yet.
+        # Pygame and PySide6 haven't published 3.14 wheels yet.
         exclude:
+          - python-version: "3.14"
+            framework: pyside6
           - python-version: "3.14"
             framework: pygame

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
+        # Pygame hasn't published 3.14 wheels yet.
+        exclude:
+          - python-version: "3.14"
+            framework: pygame

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -11,14 +11,13 @@ entitlements_path = "Entitlements.plist"
 support_path = "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Frameworks"
 runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
 {{ {
-    "3.9": "support_revision = 16",
     "3.10": "support_revision = 12",
     "3.11": "support_revision = 7",
     "3.12": "support_revision = 7",
-    "3.13": "support_revision = 9",
-    "3.14": "support_revision = 5",
+    "3.13": "support_revision = 10",
+    "3.14": "support_revision = 6",
 }.get(cookiecutter.python_version|py_tag, "") }}
-stub_binary_revision = 11
+stub_binary_revision = 12
 cleanup_paths = [
     "support/Python.xcframework/**/Headers",
     "support/Python.xcframework/**/include",


### PR DESCRIPTION
Python 3.9 is EOL; 3.14 is now available.

This won't pass CI until 3.14 binaries have been tagged.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
