### PR TITLE
Bump binary stub version to one built wtih macOS 26 SDK.

### DIFF
--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -17,7 +17,7 @@ runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
     "3.13": "support_revision = 12",
     "3.14": "support_revision = 8",
 }.get(cookiecutter.python_version|py_tag, "") }}
-stub_binary_revision = 12
+stub_binary_revision = 13
 cleanup_paths = [
     "support/Python.xcframework/**/Headers",
     "support/Python.xcframework/**/include",


### PR DESCRIPTION
Completes the move to a macOS 26-SDK based stub binary.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
