### PR TITLE
Run a user-provided post-install script if present

### DIFF
--- a/{{ cookiecutter.format }}/installer/scripts/postinstall
+++ b/{{ cookiecutter.format }}/installer/scripts/postinstall
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo "Post installation process started"
-
+{% if cookiecutter.console_app %}
 if [ ! -d "/usr/local/bin" ]; then
     echo "Creating /usr/local/bin directory"
     mkdir -p /usr/local/bin
@@ -8,5 +8,11 @@ fi
 
 echo "Install binary symlink"
 ln -si "/Library/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.app/Contents/MacOS/{{ cookiecutter.formal_name }}" /usr/local/bin/{{ cookiecutter.app_name }}
+{% endif %}
+# Run the user-provided post-install script, if one was included.
+if [ -e "$(dirname "$0")/_postinstall" ]; then
+    echo "Running post-install script"
+    "$(dirname "$0")/_postinstall"
+fi
 
 echo "Post installation process finished"


### PR DESCRIPTION
Adds support for the macOS `post_install_script` setting.

The templated `postinstall` script now invokes a sibling `_postinstall` script if Briefcase has installed one (from a project's `post_install_script` setting), so the user's script runs as its own process with its own interpreter. The console binary symlink is now only included for console apps.

Companion to beeware/briefcase#2903 — these need to be merged together, as the Briefcase change relies on the `_postinstall` hook added here.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: Claude Code (Opus 4.8)
