### PR TITLE
Add support for non-framework app builds.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -14,6 +14,7 @@
     "host_arch": "arm64",
     "python_version": "3.X.0",
     "min_os_version": "11.0",
+    "use_framework": true,
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension",
         "briefcase.integrations.cookiecutter.PListExtension",

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -21,7 +21,7 @@ runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
     "3.13": "support_revision = 14",
     "3.14": "support_revision = 10",
 }.get(cookiecutter.python_version|py_tag, "") }}
-stub_binary_revision = 14
+stub_binary_revision = "x2917"
 cleanup_paths = [
 {% if cookiecutter.use_framework -%}
     "support/Python.xcframework/**/Headers",

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -21,7 +21,7 @@ runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
     "3.13": "support_revision = 14",
     "3.14": "support_revision = 10",
 }.get(cookiecutter.python_version|py_tag, "") }}
-stub_binary_revision = "x2917"
+stub_binary_revision = "b15"
 cleanup_paths = [
 {% if cookiecutter.use_framework -%}
     "support/Python.xcframework/**/Headers",

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -8,7 +8,11 @@ app_path = "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Resources/ap
 app_packages_path = "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Resources/app_packages"
 info_plist_path = "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Info.plist"
 entitlements_path = "Entitlements.plist"
+{% if cookiecutter.use_framework -%}
 support_path = "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Frameworks"
+{% else -%}
+support_path = "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Resources/python"
+{% endif -%}
 runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
 {{ {
     "3.10": "support_revision = 14",
@@ -19,10 +23,13 @@ runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
 }.get(cookiecutter.python_version|py_tag, "") }}
 stub_binary_revision = 14
 cleanup_paths = [
+{% if cookiecutter.use_framework -%}
     "support/Python.xcframework/**/Headers",
     "support/Python.xcframework/**/include",
     "support/Python.xcframework/**/python*/config-*-darwin",
     "support/Python.xcframework/**/pkgconfig",
+{% else -%}
+{% endif -%}
 ]
 icon = "{{ cookiecutter.formal_name|escape_toml }}.app/Contents/Resources/{{ cookiecutter.app_name }}.icns"
 {% for extension, doctype in cookiecutter.document_types.items() -%}

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -21,7 +21,7 @@ runtime_path = "Python.xcframework/macos-arm64_x86_64/Python.framework"
     "3.13": "support_revision = 14",
     "3.14": "support_revision = 10",
 }.get(cookiecutter.python_version|py_tag, "") }}
-stub_binary_revision = "b15"
+stub_binary_revision = "15"
 cleanup_paths = [
 {% if cookiecutter.use_framework -%}
     "support/Python.xcframework/**/Headers",


### PR DESCRIPTION
Allow for projects where the environment manager is responsible for providing Python, and thus provides a "non-framework" Python.

This uses a preview version of the stub binary (x2917), published using the Xcode template from beeware/briefcase-macOS-Xcode-template#125. The primary effect of this stub binary is to change the path used for the Python library.

Refs beeware/briefcase#2917
Refs beeware/briefcase-macOS-Xcode-template#125

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
